### PR TITLE
Add Nix build and packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 # IDE: IntelliJ
 *.iml
 .idea/
+
+result

--- a/README.md
+++ b/README.md
@@ -5,9 +5,16 @@ This application serves a websocket that runs a dramatically simplified version 
 ## Installation and Usage
 
 1. Download the [latest release](https://github.com/runtime-shady-backroom/buttplug-lite/releases/latest).
-2. Run buttplug-lite-windows.exe (or your operating system's appropriate binary if you aren't on Windows. Builds are also provided for macOS and Linux.)
+2. Run buttplug-lite-windows.exe (or your operating system's appropriate binary if you aren't on Windows. Builds are also provided for macOS and Linux. See the section below for a way to use this via the Nix package manager)
 3. Add tags for the devices you plan to use.
 4. Press "apply configuration" to save your settings and apply them to the current server.
+
+### Install via Nix
+
+1. To use this, you need to make use of the Flake system. If you dont know what that means, search it up before you continue.
+2. In your flake.nix file, add `buttplug-lite = { url = "github:runtime-shady-backroom/buttplug-lite?ref=master"; inputs.nixpkgs.follows = "nixpkgs"; };` to your inputs at the top of the file.
+3. Pass `buttplug-lite` through to where ever you want to use the package.
+4. Add the package `buttplug-lite.packages.x86_64-linux.default` to whatever way you use to add packages. Things like `environment.systemPackages`.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This application serves a websocket that runs a dramatically simplified version 
 
 ### Install via Nix
 
-1. To use this, you need to make use of the Flake system. If you dont know what that means, search it up before you continue.
+1. To use this, you need to make use of the Flake system. If you dont know what that means, look at https://wiki.nixos.org/wiki/Flakes before you continue. You cannot use this without making use of Flakes.
 2. In your flake.nix file, add `buttplug-lite = { url = "github:runtime-shady-backroom/buttplug-lite?ref=master"; inputs.nixpkgs.follows = "nixpkgs"; };` to your inputs at the top of the file.
 3. Pass `buttplug-lite` through to where ever you want to use the package.
 4. Add the package `buttplug-lite.packages.x86_64-linux.default` to whatever way you use to add packages. Things like `environment.systemPackages`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746461020,
+        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+      libs =
+        with pkgs;
+        with pkgs.xorg;
+        [
+          libX11
+          libGL
+          libxcb
+          libxkbcommon
+          dbus.dev
+          udev.dev
+          openssl.dev
+          wayland
+        ];
+      libraryPath = "${pkgs.lib.makeLibraryPath libs}";
+    in
+    {
+      packages.x86_64-linux = rec {
+        unwrapped = pkgs.rustPlatform.buildRustPackage {
+          pname = "buttplug-lite-unwrapped";
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            git
+          ];
+
+          buildInputs = libs;
+
+          src = ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          meta = {
+            description = "Simplified buttplug.io API for when JSON is infeasible";
+            homepage = "https://github.com/runtime-shady-backroom/buttplug-lite";
+          };
+        };
+
+        default =
+          (pkgs.runCommandNoCC "buttplug-lite" {
+            pname = "buttplug-lite";
+            inherit (unwrapped) version;
+            inherit (unwrapped) meta;
+
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+          })
+            ''
+              makeWrapper ${unwrapped}/bin/buttplug-lite $out/bin/buttplug-lite --suffix LD_LIBRARY_PATH : ${libraryPath}
+            '';
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,16 @@
             nativeBuildInputs = [ pkgs.makeWrapper ];
           })
             ''
+              mkdir -p $out/share/applications/
+              cp ${
+                pkgs.makeDesktopItem {
+                  name = "buttplug-lite";
+                  exec = "buttplug-lite";
+                  desktopName = "Buttplug Lite";
+                  comment = "Simplified buttplug.io API for when JSON is infeasible";
+                }
+              }/share/applications/buttplug-lite.desktop $out/share/applications/
+
               makeWrapper ${unwrapped}/bin/buttplug-lite $out/bin/buttplug-lite --suffix LD_LIBRARY_PATH : ${libraryPath}
             '';
       };


### PR DESCRIPTION
This adds a way to install this program via a Package Manager called Nix.
There is no infrastructure required for this from the side of the repo or the owner of the repo.

I added a low maintenance flake.nix, it grabs the version of the program and hash of the deps from the Cargo files, so there is no maintenance of that kind required. The flake.lock file is required for this to work, but doesnt actually do anything in the end if people follow the instructions. 

I also added a section to the README to explain how to use this.

Nix is a package manager that is used in NixOS but also can be added to basically any Linux distro. So it is (assuming people are willing to add nix to their system) a universal linux package that will not have any dependency issues like the binary in the releases has.

I recognize that this is probably arcane stuff to someone who hasnt heard of Nix, so feel free to ask any questions you have and also to ping me if there is anything that needs a touch in the future for the nix stuff. Im happy to maintain that part of the repo as long as you let me know when you need me.

This can also be used to easily build this program locally when nix is used. For now i did some basic things like x86 Linux only and no dev shell, but if there is demand im happy to put more effort in to add darwin (MacOS with Nix) support or even aarch64 or a dev shell or whatever people ask for.